### PR TITLE
Maquette2 document page fixes + collection header adjustements

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -996,7 +996,8 @@ a.noteref sup {
     --text-decoration-hover: underline dotted;
 }
 
-.dots-button {
+a.dots-button,
+button.dots-button {
     width: var(--button-size);
     height: var(--button-size);
     min-width: var(--button-size);
@@ -1005,6 +1006,12 @@ a.noteref sup {
     font-size: var(--button-font-size);
     font-weight: 700;
     cursor: pointer;
+    color: unset !important;
+
+    &:hover,
+    &:focus {
+        color: inherit;
+    }
 
     & > .icon-wrapper {
         width: 100%;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1006,7 +1006,7 @@ button.dots-button {
     font-size: var(--button-font-size);
     font-weight: 700;
     cursor: pointer;
-    color: unset !important;
+    color: inherit;
 
     &:hover,
     &:focus {

--- a/src/assets/images/IconNotes.vue
+++ b/src/assets/images/IconNotes.vue
@@ -59,8 +59,7 @@ const cssVars = {
   border-color: #e5e5e5;
 }
 
-.is-opened > .icon-wrapper,
-.icon-wrapper:hover {
+.is-notes-opened > .icon-wrapper {
   color: #FFF;
   background-color: var(--fill-color);
 
@@ -68,4 +67,16 @@ const cssVars = {
     fill: #CCC;
   }
 }
+
+@media screen and (min-width: 1024px) {
+  :not(.is-notes-opened) > .icon-wrapper:hover {
+    color: #FFF;
+    background-color: var(--fill-color);
+
+    .note-no {
+      fill: #CCC;
+    }
+  }
+}
+
 </style>

--- a/src/components/CollectionTOC.vue
+++ b/src/components/CollectionTOC.vue
@@ -1729,6 +1729,16 @@ input[type=number] {
     font-size: 18px;
   }
 
+  .toc-mode .collection-toc-area-header {
+    padding: 20px 15px;
+
+    & > a {
+      padding: 0;
+    }
+  }
+  .toc-mode.collection-toc-area.expanded .toggle-btn, .toggle-btn.expanded {
+    background-size: calc(var(--button-size) * 0.65) auto;
+  }
   .mixed-mode .collection-toc-area .menu.expanded ul.tree li a {
     padding: 13px var(--mobile-margin) 11px;
   }

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -433,9 +433,13 @@ div.toc-area-content.toc-content {
     .tree {
       columns: 1;
       gap: 15px;
-      overflow: auto;
-      max-height: calc(100vh - 280px); /* Horizontal scroll */
+      overflow-x: auto;
+      overflow-y: hidden;
+      max-height: calc(100vh - 320px); /* Horizontal scroll */
       padding: 20px 0;
+
+      position: relative;
+      z-index: 1;
     }
   }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -59,10 +59,11 @@ if (isDocProjectIdIncluded) {
       // console.log('scrollBehavior to', to);
       // console.log('scrollBehavior from', from);
 
-      const defaultTop = 0; // window.innerWidth < 1024 ? 45 : 82;
+      const defaultTop = window.innerWidth < 1024 ? 45 : 82;
 
       if (to.path === from.path && to.hash.length) {
         // Local anchors
+        console.log('scrollBehavior Local anchors', to.path);
         return {
           el: to.hash,
           behavior: 'smooth',
@@ -70,27 +71,52 @@ if (isDocProjectIdIncluded) {
         }
       }
 
+      const documentScroll = window.documentScrollY ? window.documentScrollY : window.scrollY;
       const documentArea = document.querySelector('.navigation-document');
       if (documentArea) {
-        const documentAreaTop = documentArea.getBoundingClientRect().top + window.scrollY;
-        if (window.scrollY >= documentAreaTop) {
-          // If window scroll is beyond sticky navigation bar
-          const documentAreaElement = document.querySelector('.document-area')
-          if (documentAreaElement) {
+
+        const documentAreaElement = document.querySelector('.document-area')
+        const documentAreaElementTop = documentAreaElement.getBoundingClientRect().top
+
+        const documentAreaTop = documentArea.getBoundingClientRect().top + documentScroll;
+        const breadcrumbPanel = document.getElementById('breadcrumb-panel');
+        const breadcrumbPanelHeight = ! breadcrumbPanel ? 0 : breadcrumbPanel.offsetHeight;
+
+        console.log('scrollBehavior documentArea ?', documentAreaTop, '<' , documentScroll, window.scrollY, '?', breadcrumbPanelHeight + 157);
+
+        if (documentAreaElementTop <= defaultTop) {
+          // If window scroll is beyond sticky navigation bar, scroll the top of the document under the sticky menu
+            console.log('scrollBehavior documentArea1', defaultTop);
             return {
               el: documentAreaElement,
               top: defaultTop,
             }
-          } else {
-            return { top: 0 }
+        } else if (documentScroll > breadcrumbPanelHeight + 157) {
+          console.log('scrollBehavior documentArea2', defaultTop);
+          return {
+            el: documentAreaElement,
+            top: defaultTop,
           }
         }
       }
 
+      if (window.documentScrollY !== window.scrollY) {
+        console.log('scrollBehavior documentArea3', documentScroll, window.scrollY);
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            resolve({ top: documentScroll, behavior: 'instant' })
+          }, 0)
+        })
+      }
+
       // else scroll is unchanged...
+      console.log('scrollBehavior else1');
     }
   })
+
 } else {
+
+  console.log('scrollBehavior else2');
   router = createRouter({
     history: createWebHistory(rootURL),
     routes: [

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -59,7 +59,7 @@ if (isDocProjectIdIncluded) {
       // console.log('scrollBehavior to', to);
       // console.log('scrollBehavior from', from);
 
-      const defaultTop = window.innerWidth < 1024 ? 45 : 82;
+      const defaultTop = 0; // window.innerWidth < 1024 ? 45 : 82;
 
       if (to.path === from.path && to.hash.length) {
         // Local anchors

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -373,8 +373,8 @@
           <button
             type="button"
             class="dots-button notes-btn"
-            :class="{ 'is-opened': isNotesOpened }"
-            aria-pressed="isNotesOpened"
+            :class="{ 'is-notes-opened': isNotesOpened }"
+            :aria-pressed="isNotesOpened"
             aria-label="Afficher les notes"
             @click="toggleNotes"
           >
@@ -2181,10 +2181,6 @@ export default {
 
 .controls .notes-btn {
   color: #C3C3C3;
-
-  &.is-opened {
-    color: var(--fill-color);
-  }
 }
 .controls button:focus-visible {
   outline: 2px solid #B9192F;

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2672,6 +2672,7 @@ div.remove-bottom-padding #article {
       &.is-opened {
         color: white;
       }
+
       &.disabled {
         pointer-events: none;
         opacity: 0.2;
@@ -2861,6 +2862,7 @@ div.remove-bottom-padding #article {
   flex-direction: row;
   justify-content: right;
   height: 100%;
+  color: var(--fill-color);
 }
 .navigation-document-top a span {
   line-height: 1.25;

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2834,6 +2834,7 @@ div.remove-bottom-padding #article {
   z-index: 11;
 }
 
+
 .navigation-document {
   position: relative;
   display: flex;
@@ -3272,8 +3273,8 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   }
 
   .toc-aside-is-opened .document-views {
-    width: 100% !important;
-    margin-left: calc(105px - 100vw);
+    width: calc(100vw - 40px) !important;
+    margin-left: calc(125px - 100vw);
 
     &::before {
       content: "";
@@ -3282,7 +3283,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
       height: 100%;
       background-color: rgba(0,0,0,0.65);
       position: absolute;
-      left: 0;
+      left: -20px;
       top: 0;
     }
   }
@@ -3475,14 +3476,16 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
 
   /* Negative margin is necessary to maintain the sticky behavior */
   .toc-aside-is-opened .toc-area-aside {
-    width: calc(100vw - 20px);
+    width: calc(100vw - 60px);
+    margin-left: 0;
   }
 
   .toc-aside-is-opened .document-views {
-    margin-left: calc(75px - 100vw);
+    width: 100vw !important;
+    margin-left: calc(60px - 100vw);
 
     &::before {
-      left: -20px;
+      left: 0;
     }
   }
 

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2058,6 +2058,7 @@ export default {
 }
 .toc-area .toc-area-content aside {
   width: 100% !important;
+  overflow-x: hidden;
   padding: 20px 10px !important;
 }
 .toc-area .toc-area-content nav > ol.tree {

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -3176,7 +3176,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   background-color: var(--meta-area-fill-color);
 }
 
-.tab-header button {
+.tab-header button.dots-button {
   width: auto;
   background: #FFF;
   font-family: var(--font-primary), sans-serif;
@@ -3185,7 +3185,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   border: 1px solid var(--fill-color);
 }
 
-.tab-header button.active {
+.tab-header button.dots-button.active {
   color: white;
   background-color: var(--fill-color);
 }

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -114,6 +114,7 @@
           </div>
           <div
             v-if="activeObject"
+            id="breadcrumb-panel"
             class="breadcrumb-panel is-opened"
           >
             <div class="tab-header">
@@ -616,6 +617,9 @@ export default {
     })
 
     const updateMiradorTopPosition = function () {
+      // Cf scrollBehavior in router index.js
+      window.documentScrollY = window.scrollY;
+
       const miradorView = document.getElementById('mirador-view')
       const textView = document.getElementById('text-view')
       console.log('Document.vue no anchor update mirador position')
@@ -1740,8 +1744,8 @@ export default {
               scrollTo()
             } else {
               // Scroll to top if no anchor
-              console.log('DocumentPage watch no anchor scrollTo Page TOP')
-              window.scrollTo({ top: 0, behavior: 'instant' })
+              console.log('scrollBehavior DocumentPage watch no anchor scrollTo Page TOP')
+              // window.scrollTo({ top: 0, behavior: 'instant' })
             }
             isLoading.value = true
           } else {
@@ -1919,6 +1923,7 @@ export default {
       window.removeEventListener('resize', onResize)
       document.body.removeEventListener('click', closeTOC);
 
+      window.documentScrollY = false;
     })
 
     return {

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1049,8 +1049,9 @@ input[type=number] {
     left: calc( 2 * var(--mobile-margin));
   }
 
-  #home-article {
-    padding: 20px var(--mobile-margin) 0 !important;
+  #home-article.article {
+    padding: 12px var(--mobile-margin) 10px !important;
+    margin-bottom: 0;
   }
 
   .home-article-wrapper {


### PR DESCRIPTION
- FIX TOC summary horizontal scroll of entire app on mobile (when summary is larger than viewport)
- Collection header padding + close button on mobile
- Collection A propos padding on mobile
- Aside TOC : FIX keep document scroll position with / without TOC
- Document PRv/Next prevent hover style on mobile
- Document page Note button style on mobile (on/off)
- TOC summary horizontal scroll : change style overflow to check on Safari mobile
 