### PR TITLE
Maquette2 : document scroll with metadata, breadcrumbs scroll position, notes aside-bottom menu

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -769,6 +769,7 @@ a.noteref sup {
 .aside-noteref-content {
     font-family: var(--font-primary), sans-serif;
     font-size: var(--font-small-size);
+    line-height: 1.25;
 }
 
 .aside-noteref-content a.notebottom,

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -640,7 +640,7 @@ p.header-baseline span {
 
     position: absolute;
     right: 35px;
-    width: 40px;
+    width: var(--button-size);
 }
 
 /* Notes */

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -660,16 +660,17 @@ a.noteref sup {
     transform: translateY(-3px);
     display: inline-block;
     height: auto;
-    padding: 2px 4px 1px;
+    padding: 3px 4px 1px;
     background: #000;
     margin:0 4px;
 
     font-weight: bold;
-    font-size: 0.8em;
+    font-size: 0.65rem;
     color: #FFF;
     line-height: 1;
     text-indent: 0;
     text-align: center;
+    vertical-align: middle;
 }
 
 .notes-opened .aside-noteref-parent{

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -444,6 +444,7 @@ table td:not([align]), table th:not([align]) {
 
 .layout-navbar {
     grid-area: header;
+    height: 70px;
 }
 .layout-main {
     grid-area: main;
@@ -874,6 +875,7 @@ a.noteref sup {
 }
 
 @media screen and (max-width: 768px) {
+
     .app-width-padding {
         padding-left: var(--mobile-margin);
         padding-right: var(--mobile-margin);
@@ -882,6 +884,10 @@ a.noteref sup {
         margin: 0;
         max-width: 100%;
         padding: 0 var(--mobile-margin);
+    }
+
+    .layout-grid-container {
+        display: block;
     }
 
     .toggle-btn {
@@ -920,11 +926,13 @@ a.noteref sup {
 }
 
 @media screen and (max-width: 640px) {
+
     p.header-baseline {
         margin: auto;
         width: 60%;
         text-align: center;
     }
+
     .layout-navbar:not(.document) {
         position: fixed;
         left:0;
@@ -933,6 +941,10 @@ a.noteref sup {
 
         width: 100vw;
         z-index: 25;
+
+        & + .layout-main {
+            margin-top: var(--top-navbar-height);
+        }
     }
 }
 
@@ -966,6 +978,7 @@ a.noteref sup {
     --button-size: 40px;
     --button-border-radius: 4px;
     --button-font-size: 14px;
+    --top-navbar-height: 70px;
 
     @media screen and (max-width: 768px) {
         --font-default-size : 14px;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -673,6 +673,14 @@ a.noteref sup {
     vertical-align: middle;
 }
 
+a.noteref:focus {
+    outline: none;
+
+    sup {
+        background: var(--fill-color);
+    }
+}
+
 .notes-opened .aside-noteref-parent{
     visibility: visible;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -706,6 +706,11 @@ a.noteref sup {
     line-height: inherit;
 }
 
+.images-mode .aside-noteref-list,
+.text-and-images-mode .aside-noteref-list {
+    margin: 0;
+}
+
 .aside-noteref-list:not(:empty)::before {
     content: "";
     display: block;

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -414,6 +414,8 @@ export default {
     flex: auto;
   }
   .footer .title-container {
+    width: auto;
+    
     & > .title {
       font-size: 24px;
     }

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -554,14 +554,18 @@ ul.submenu a:hover {
     display: flex;
     margin-top: 0;
     z-index: 10; /* cf documentation menu */
+    padding-left: 12px;
+    padding-right: 12px;
 
     /*position: fixed;
     top:0;*/
     width: 100vw;
   }
   .logo-header {
+    width: 50px;
     min-width: 45px;
     max-width: unset;
+    margin-right: 12px;
   }
   .level-left .level-item:not(:last-child),
   .level-right .level-item:not(:last-child) {
@@ -598,9 +602,16 @@ ul.submenu a:hover {
 
     & > a.level-item-external {
       line-height: 1.2;
+
       &:not(:first-child) {
         display: block !important;
       }
+
+      &:nth-child(2) {
+        margin-left: 15px;
+        padding-left: 15px;
+      }
+
       /*&:first-child {
         top: 22px;
         position: fixed;
@@ -610,6 +621,7 @@ ul.submenu a:hover {
         display: none;
       }
     }
+
   }
 
   .level-right {
@@ -619,6 +631,7 @@ ul.submenu a:hover {
   .level-left {
     width: 100%;
     overflow: hidden;
+    gap: 10px;
   }
 
   .level-left .level-item {

--- a/src/components/Burger.vue
+++ b/src/components/Burger.vue
@@ -63,7 +63,7 @@ export default {
     width: 100%;
   }
   .navbar-burger span {
-    width: 33px;
+    width: 28px;
     background-color: #FFFFFF;
     height: 3px;
     right: 0;

--- a/src/components/CollectionCardWithToc.vue
+++ b/src/components/CollectionCardWithToc.vue
@@ -962,9 +962,10 @@ input[type=number] {
 
   .mixed-mode .collection-wrapper {
     flex: 100% 0 0;
-    border-radius: 30px 30px 0 0;
+    border-radius: 15px 15px 0 0;
     align-self: unset;
     margin-right: 0;
+    padding: 25px 35px 30px 20px;
   }
   .mixed-mode .collection-toc-area {
     padding-bottom: 50px;

--- a/src/components/Document.vue
+++ b/src/components/Document.vue
@@ -342,8 +342,6 @@ export default {
         notesPresent = hasNotesInHTML(data)
       }
 
-      console.log("notesPresent", notesPresent, mediaType.value)
-
       // Emit presence of notes to parent
       emit('has-notes', notesPresent)
       hasNotes.value = notesPresent
@@ -399,7 +397,7 @@ export default {
           const yOffset = -90
           const y = el.getBoundingClientRect().top + window.scrollY + yOffset
           console.log('Document.vue scrollTo y : ', y)
-          window.scrollTo({ top: y, behavior: 'instant' })
+          //window.scrollTo({ top: y, behavior: 'instant' })
         }
       } /* removing scroll top for now 06/02/2026 else {
         // Scroll to the top of Page if no anchor and new route or to reader TOP in reading context
@@ -445,6 +443,8 @@ export default {
       asideNotesParent = main.querySelector('.aside-noteref-parent')
       asideNotes = main.querySelector('.aside-noteref-list')
 
+      console.log('initAsideNotes', asideNotes)
+
       if (!asideNotesParent) {
         asideNotesParent = document.createElement('aside')
         asideNotesParent.classList.add('aside-noteref-parent')
@@ -489,7 +489,7 @@ export default {
 
         if (noteTop > documentInViewTop && noteTop < documentInViewBottom) {
           const noteId = noteRef.getAttribute('href')?.substring(1)
-          const noteElement = document.querySelector(`.note[id="${noteId}"]`)
+          const noteElement = document.querySelector(`.fn-note[id="${noteId}"]`)
           if (!noteElement) return
 
           notesInView.push({

--- a/src/components/Document.vue
+++ b/src/components/Document.vue
@@ -489,7 +489,7 @@ export default {
 
         if (noteTop > documentInViewTop && noteTop < documentInViewBottom) {
           const noteId = noteRef.getAttribute('href')?.substring(1)
-          const noteElement = document.querySelector(`.fn-note[id="${noteId}"]`)
+          const noteElement = document.querySelector('[id="${noteId}"], [class$="note"]')
           if (!noteElement) return
 
           notesInView.push({

--- a/src/components/DocumentMetadata.vue
+++ b/src/components/DocumentMetadata.vue
@@ -436,7 +436,6 @@ export default {
 .is-opened .toggle-btn {
   background: url(../assets/images/croix.svg) center / cover no-repeat;
 }
-
 .document-metadata-header > a {
   text-decoration: none;
   border: none;
@@ -481,6 +480,12 @@ aside.menu > .columns > .column:nth-child(3) {
     font-weight: normal;
     font-style: normal;
     color: #4a4a4a;
+
+    &:hover {
+      color: #000;
+      border-bottom: dotted 1px #000;
+      background-color: transparent;
+    }
   }
 }
 .title {

--- a/src/components/PageBreak.vue
+++ b/src/components/PageBreak.vue
@@ -8,7 +8,7 @@
         <img
           class="pb-thumbnail"
           :src="thumbnail"
-          @click.prevent="goToCanvas()"
+          @click.prevent="goToCanvas($event)"
         />
       </div>
     </article>
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import { inject } from 'vue'
+import {inject, nextTick} from 'vue'
 
 export default {
   name: 'PageBreak',
@@ -27,8 +27,14 @@ export default {
     const mirador = inject('mirador')
     const layout = inject('variable-layout')
 
-    const goToCanvas = function () {
+    const goToCanvas = function (event) {
       if (mirador) {
+
+        // Thumbnail y-position and scroll before mode change
+        const imageThumbnail = event.target;
+        const imageThumbnailY = imageThumbnail.getBoundingClientRect().top;
+        const textScrollBefore = window.scrollY;
+
         console.log(props.canvasId)
         const currentCanvasId = Object.values(mirador.miradorStore.getState().windows)[0].canvasId
         console.log('currentCanvasId / props.canvasId', currentCanvasId, props.canvasId, currentCanvasId.substring(currentCanvasId.lastIndexOf('/f') + 1, currentCanvasId.length))
@@ -36,6 +42,7 @@ export default {
           layout.changeViewMode('init')
           mirador.setCanvasId(props.canvasId.substring(0, props.canvasId.lastIndexOf('/f') + 1) + 'f1')
         } else {
+
           mirador.setCanvasId(props.canvasId)
           // if (layout.miradorVisible != true) {
           // layout.setMiradorVisible(true);
@@ -44,6 +51,16 @@ export default {
           }
           // }
         }
+
+        // Thumbnail y-position and scroll after mode change
+        nextTick(function () {
+          const textScrollAfter = textScrollBefore + (imageThumbnail.getBoundingClientRect().top - imageThumbnailY);
+          window.scrollTo({
+            top: textScrollAfter,
+            behavior: 'instant'
+          })
+        });
+
       }
     }
 

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -376,7 +376,7 @@ input[type=number] {
 
   /* Font sizes */
   .pagination-documents-count {
-    font-size: 16px;
+    font-size: 19px;
   }
 
   .pagination-controls  {

--- a/src/components/TOC.vue
+++ b/src/components/TOC.vue
@@ -435,6 +435,7 @@ div.toc-area-content.toc-content {
       gap: 15px;
       overflow-x: auto;
       overflow-y: hidden;
+      scrollbar-width: thin;
       max-height: calc(100vh - 320px); /* Horizontal scroll */
       padding: 20px 0;
 
@@ -624,6 +625,7 @@ div.bottom-toc {
   justify-content: space-between;
   align-items: center;
   margin-top: 10px;
+  padding-bottom: 10px;
 
   &.is-hidden {
     display: none;

--- a/src/composables/use-layout.js
+++ b/src/composables/use-layout.js
@@ -42,6 +42,7 @@ export default function useLayout () {
   const changeViewMode = function (v) {
     //viewMode.value = v
     console.log('changeViewMode before : ', viewMode.value, v)
+    const isMobile = window.innerWidth < 768;
     if (v === 'init') {
       viewMode.value = 'text-mode'
     } else if (viewMode.value === 'init' && v === 'text-mode') {
@@ -49,15 +50,15 @@ export default function useLayout () {
     } else if (viewMode.value === 'text-mode' && v === 'text-mode') {
       viewMode.value = 'images-mode'
     } else if (viewMode.value === 'text-mode' && v === 'images-mode') {
-      viewMode.value = 'text-and-images-mode'
+      viewMode.value = isMobile ? 'images-mode' : 'text-and-images-mode'
     } else if (viewMode.value === 'images-mode' && v === 'images-mode') {
       viewMode.value = 'text-mode'
     } else if (viewMode.value === 'images-mode' && v === 'text-mode') {
-      viewMode.value = 'text-and-images-mode'
+      viewMode.value = isMobile ? 'text-mode' : 'text-and-images-mode'
     } else if (viewMode.value === 'text-and-images-mode' && v === 'text-mode') {
-      viewMode.value = 'images-mode'
+      viewMode.value = isMobile ? 'text-mode' : 'images-mode'
     } else if (viewMode.value === 'text-and-images-mode' && v === 'images-mode') {
-      viewMode.value = 'text-mode'
+      viewMode.value = isMobile ? 'images-mode' : 'text-mode'
     }
     if (isTOCMenuOpened.value && String(viewMode.value).includes('images')) {
       isTOCMenuOpened.value = false

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,42 +75,30 @@ if (isDocProjectIdIncluded) {
       const documentArea = document.querySelector('.navigation-document');
       if (documentArea) {
 
-        const documentAreaElement = document.querySelector('.document-area')
-        const documentAreaElementTop = documentAreaElement.getBoundingClientRect().top
+        const navTopContainer = document.getElementById('navigation-row-top-container');
+        const navTopContainerHeight = ! navTopContainer ? 0 : navTopContainer.offsetHeight;
 
-        const documentAreaTop = documentArea.getBoundingClientRect().top + documentScroll;
-        const breadcrumbPanel = document.getElementById('breadcrumb-panel');
-        const breadcrumbPanelHeight = ! breadcrumbPanel ? 0 : breadcrumbPanel.offsetHeight;
+        console.log('scrollBehavior documentArea ?', documentScroll, '>=' , navTopContainerHeight + defaultTop, navTopContainerHeight);
 
-        console.log('scrollBehavior documentArea ?', documentAreaTop, '<' , documentScroll, window.scrollY, '?', breadcrumbPanelHeight + 157);
-
-        if (documentAreaElementTop <= defaultTop) {
+        if (documentScroll >= navTopContainerHeight + defaultTop) {
           // If window scroll is beyond sticky navigation bar, scroll the top of the document under the sticky menu
             console.log('scrollBehavior documentArea1', defaultTop);
-            return {
-              el: documentAreaElement,
-              top: defaultTop,
-            }
-        } else if (documentScroll > breadcrumbPanelHeight + 157) {
-          console.log('scrollBehavior documentArea2', defaultTop);
-          return {
-            el: documentAreaElement,
-            top: defaultTop,
-          }
+            return new Promise((resolve, reject) => {
+              setTimeout(() => {
+                resolve({ top: navTopContainerHeight + defaultTop, behavior: 'instant' })
+              }, 0)
+            })
         }
-      }
 
-      if (window.documentScrollY !== window.scrollY) {
-        console.log('scrollBehavior documentArea3', documentScroll, window.scrollY);
         return new Promise((resolve, reject) => {
           setTimeout(() => {
             resolve({ top: documentScroll, behavior: 'instant' })
           }, 0)
         })
+
       }
 
       // else scroll is unchanged...
-      console.log('scrollBehavior else1');
     }
   })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -59,11 +59,11 @@ if (isDocProjectIdIncluded) {
       // console.log('scrollBehavior to', to);
       // console.log('scrollBehavior from', from);
 
-      const defaultTop = window.innerWidth < 1024 ? 45 : 82;
+      const defaultTop = window.innerWidth < 768 ? 45 : 82;
 
       if (to.path === from.path && to.hash.length) {
         // Local anchors
-        console.log('scrollBehavior Local anchors', to.path);
+        console.log('scrollBehavior Local anchors', to.path, 'window.innerWidth', window.innerWidth, defaultTop);
         return {
           el: to.hash,
           behavior: 'smooth',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,17 +75,22 @@ if (isDocProjectIdIncluded) {
       const documentArea = document.querySelector('.navigation-document');
       if (documentArea) {
 
+        const topNavBar = document.querySelector('.layout-navbar:first-child');
+        const topNavBarHeight = topNavBar.offsetHeight;
+
         const navTopContainer = document.getElementById('navigation-row-top-container');
         const navTopContainerHeight = ! navTopContainer ? 0 : navTopContainer.offsetHeight;
 
+        const totalHeaderHeight = navTopContainerHeight + topNavBarHeight;
+
         console.log('scrollBehavior documentArea ?', documentScroll, '>=' , navTopContainerHeight + defaultTop, navTopContainerHeight);
 
-        if (documentScroll >= navTopContainerHeight + defaultTop) {
+        if (documentScroll >= totalHeaderHeight) {
           // If window scroll is beyond sticky navigation bar, scroll the top of the document under the sticky menu
-            console.log('scrollBehavior documentArea1', defaultTop);
+            console.log('scrollBehavior documentArea1', navTopContainerHeight + defaultTop, defaultTop);
             return new Promise((resolve, reject) => {
               setTimeout(() => {
-                resolve({ top: navTopContainerHeight + defaultTop, behavior: 'instant' })
+                resolve({ top: totalHeaderHeight, behavior: 'instant' })
               }, 0)
             })
         }

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -193,6 +193,7 @@ article.about {
   align-content: center;
   padding-top: 64px;
   padding-bottom: 150px;
+  overflow-x: hidden;
 
   & .tab-menu {
     height: 100%;

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -282,11 +282,11 @@ article.about .page-header h1,
 }
 .about .about-content h2,
 .about .content h2 {
-  margin: 0 0 45px;
+  margin: 25px 0;
   font-family: var(--font-primary), sans-serif;
   font-size: 30px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.2;
   color: var(--document-text-color);
 }
 .about .about-content h3,
@@ -444,10 +444,13 @@ article.about .page-header h1,
     text-align: left;
     width: 80%;
   }
-
+  .about .about-content h2,
+  .about .content h2 {
+    font-size: 24px;
+  }
   .about-page .tab-menu {
     padding: 0;
-    margin: 0 0 40px;
+    margin: 0 0 10px;
   }
 
   /*

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -339,7 +339,7 @@
         class="controls-list"
         :class="isControlsOpened ? 'is-opened' : ''"
       >
-        <li v-if="manifestIsAvailable">
+        <li v-if="manifestIsAvailable" >
           <button
             type="button"
             class="dots-button text-btn"
@@ -354,7 +354,7 @@
           </button>
         </li>
 
-        <li v-if="manifestIsAvailable" class="images-parent-btn">
+        <li v-if="manifestIsAvailable" >
           <button
             type="button"
             class="dots-button images-btn"
@@ -3465,8 +3465,22 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
     display: none;
   }
 
-  .controls .images-parent-btn {
-    display: none;
+  .text-mode .controls {
+    .text-btn {
+      pointer-events: none;
+    }
+    .images-btn {
+      pointer-events: auto;
+    }
+  }
+
+  .images-mode .controls {
+    .text-btn {
+      pointer-events: auto;
+    }
+    .images-btn {
+      pointer-events: none;
+    }
   }
 
   .controls {

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2817,7 +2817,7 @@ div.remove-bottom-padding #article {
 .controls {
   position: sticky;
   top: 85px;
-  z-index: 12;
+  z-index: 10;
   pointer-events: none;
 }
 
@@ -3552,7 +3552,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   }
 
   .controls {
-    z-index: 13;
+    z-index: 10;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2993,7 +2993,7 @@ div.remove-bottom-padding #article {
 .controls {
   position: sticky;
   top: 85px;
-  z-index: 11;
+  z-index: 15; /* above document-area layer */
   pointer-events: none;
 }
 
@@ -3473,6 +3473,10 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
       top: 0;
       z-index: 11;
     }
+  }
+
+  .controls {
+    z-index: 11; /* under semi-transparent bg when aside TOC is opened */
   }
 
 }

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -369,7 +369,9 @@
           </button>
         </li>
 
-        <li v-if="hasNotes">
+        <li v-if="hasNotes"
+          class="notes-btn-parent"
+        >
           <button
             type="button"
             class="dots-button notes-btn"
@@ -3390,6 +3392,12 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
 .tab-content ul.tree, .tab-content .collection-toc-area, .tab-content .table.is-fullwidth  {
   margin: 0;
   border-radius: 0 0 6px 6px;
+}
+
+.images-mode .controls {
+  .notes-btn-parent {
+    display: none;
+  }
 }
 
 

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2632,6 +2632,24 @@ div.remove-bottom-padding #article {
     position: relative;
   }
 
+  .footnotes > h3 {
+    border-bottom: #E4E4E4 4px solid !important;
+  }
+
+  .footnotes ol {
+    list-style-position: inside;
+
+    & > li {
+      position: relative;
+      margin-left: 30px;
+
+      & > a.noteback {
+        top: 0;
+      }
+    }
+  }
+
+  /*
   .footnotes::before {
     content: "Notes";
     display: block;
@@ -2649,6 +2667,8 @@ div.remove-bottom-padding #article {
     width: 100%;
     border-top: #E4E4E4 4px solid !important;
   }
+
+   */
 
   .footnotes > *:first-child {
     display: block;
@@ -3396,6 +3416,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
       position: absolute;
       left: -20px;
       top: 0;
+      z-index: 11;
     }
   }
 

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2925,7 +2925,7 @@ div.remove-bottom-padding #article {
 .controls {
   position: sticky;
   top: 85px;
-  z-index: 10;
+  z-index: 11;
   pointer-events: none;
 }
 
@@ -3660,7 +3660,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   }
 
   .controls {
-    z-index: 10;
+    z-index: 11;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -747,7 +747,9 @@ export default {
           collCrumbsWithEllipsis.value = true
         }
       })
-      el.scrollLeft = el.scrollWidth - el.clientWidth
+
+      // Horizontal scroll : scroll to last item
+      breadcrumbScrollToLastItem('instant')
       updateMeasurements()
     }
     let isResizing = false
@@ -755,7 +757,6 @@ export default {
     const onColBreadcrumbScroll = (event) => {
       if (isResizing) return  // ignoring parasite scroll from browser
       const target = event.target
-      console.log('onColBreadcrumbScroll', target)
       updateMeasurements()
       colBreadcrumbScrollLeft.value = target.scrollLeft
       colBreadcrumbClientWidth.value = target.clientWidth
@@ -765,7 +766,6 @@ export default {
     const breadcrumbToLeft = function() {
       console.log('DOM breadcrumbToLeft', breadcrumbEl.value)
       if (!breadcrumbEl.value) return
-
       const el = breadcrumbEl.value
 
       el.scrollTo({
@@ -774,9 +774,22 @@ export default {
       })
     }
 
+    const breadcrumbScrollToLastItem = function(behavior = 'smooth') {
+      console.log('DOM breadcrumbScrollToLastItem', breadcrumbEl.value)
+      if (!breadcrumbEl.value) return
+      const el = breadcrumbEl.value
+
+      const breadcrumbLastChild = el.querySelector('li:last-child')
+      if (breadcrumbLastChild) {
+        el.scrollTo({
+          left: breadcrumbLastChild.offsetLeft - 40,
+          behavior: behavior
+        })
+      }
+    }
+
     const breadcrumbToRight = function() {
       if (!breadcrumbEl.value) return
-
       const el = breadcrumbEl.value
 
       el.scrollTo({
@@ -813,6 +826,31 @@ export default {
       docBreadcrumbScrollWidth.value = target.scrollWidth
     }
 
+    const arianeDocScrollToLastItem = function(behavior = 'smooth') {
+      console.log('DOM arianeDocScrollToLastItem', arianeDocContainer.value)
+      if (!arianeDocContainer.value) return
+      const el = arianeDocContainer.value
+
+      const arianeLastChild = el.querySelector('li:last-child')
+      if (arianeLastChild) {
+        el.scrollTo({
+          left: arianeLastChild.offsetLeft - 30,
+          behavior: behavior
+        })
+      }
+    }
+
+    const arianeDocToRight = function(behavior = 'smooth') {
+      console.log('DOM arianeDocToRight', arianeDocContainer.value)
+      if (!arianeDocContainer.value) return
+      const el = arianeDocContainer.value
+
+      el.scrollTo({
+        left: el.scrollWidth,
+        behavior: behavior
+      })
+    }
+
     // Maintains Document Ariane horizontal scroll on right when resizing window
     const updateDocBreadcrumbHorizontalScrollAndMeasurements = function() {
       if (!arianeDocContainer.value) return
@@ -827,8 +865,8 @@ export default {
         }
       })
 
-      // Horizontal scroll
-      el.scrollLeft = el.scrollWidth - el.clientWidth
+      // Horizontal scroll : scroll to last item
+      arianeDocScrollToLastItem('instant')
       updateMeasurementsAriane()
     }
 
@@ -842,21 +880,11 @@ export default {
       docBreadcrumbScrollWidth.value = el.scrollWidth
     }
 
-    const arianeDocToRight = function() {
-      console.log('DOM arianeDocToRight', arianeDocContainer.value)
-      if (!arianeDocContainer.value) return
-      const el = arianeDocContainer.value
-
-      el.scrollTo({
-        left: el.scrollWidth,
-        behavior: 'smooth'
-      })
-    }
-
     const initArianeDoc = function() {
       updateDocBreadcrumbHorizontalScrollAndMeasurements();
+      breadcrumbScrollToLastItem();
       updateHorizontalScrollAndMeasurements();
-      arianeDocToRight();
+      arianeDocScrollToLastItem();
     }
 
 
@@ -1911,7 +1939,7 @@ export default {
 
     watch(breadcrumbEl, (val) => {
       console.log('DOM breadcrumbEl updated:', val)
-      nextTick().then(breadcrumbToRight)
+      nextTick().then(breadcrumbScrollToLastItem)
     })
 
     function scrollTo() {
@@ -2029,11 +2057,13 @@ export default {
       onDocBreadcrumbScroll,
       breadcrumbToLeft,
       breadcrumbToRight,
+      breadcrumbScrollToLastItem,
       colFadeLeftVisible,
       colFadeRightVisible,
       docFadeLeftVisible,
       docFadeRightVisible,
       arianeDocContainer,
+      arianeDocScrollToLastItem,
       arianeDocToRight,
       initArianeDoc,
       activeBreadcrumb,

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -882,9 +882,7 @@ export default {
 
     const initArianeDoc = function() {
       updateDocBreadcrumbHorizontalScrollAndMeasurements();
-      breadcrumbScrollToLastItem();
       updateHorizontalScrollAndMeasurements();
-      arianeDocScrollToLastItem();
     }
 
 

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -16,7 +16,7 @@
       :toc="flatTOC"
       @change="closeModal"
     />-->
-    <div class="navigation-row-top-container">
+    <div class="navigation-row-top-container" id="navigation-row-top-container">
       <div class="navigation-row-top app-width-margin">
         <div class="ariane-collection-top">
           <div
@@ -114,7 +114,6 @@
           </div>
           <div
             v-if="activeObject"
-            id="breadcrumb-panel"
             class="breadcrumb-panel is-opened"
           >
             <div class="tab-header">

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -3394,8 +3394,9 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   border-radius: 0 0 6px 6px;
 }
 
-.images-mode .controls {
-  .notes-btn-parent {
+.images-mode {
+  .notes-opened .aside-noteref-parent,
+  .controls .notes-btn-parent {
     display: none;
   }
 }
@@ -3505,6 +3506,12 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
   .text-mode .document-views,
   .text-and-images-mode .document-views {
     margin-right: 0;
+  }
+
+  .mirador-view {
+    height: calc(100vh - 170px);
+    min-height: 80vh;
+    max-height: 100vh;
   }
 
   .text-and-images-mode .document-views .mirador-view {

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -2741,7 +2741,7 @@ div.remove-bottom-padding #article {
 
   .footnotes aside.note {
     position: relative;
-    padding: 0 0 0 25px;
+    padding: 0 0 0 40px;
     margin: 0 0 40px;
     border: none;
   }
@@ -2757,7 +2757,7 @@ div.remove-bottom-padding #article {
   .footnotes aside.note a.noteback {
     position: absolute;
     left: 0;
-    top: 0;
+    top: -2px;
     display: inline;
     width: auto;
     margin: 0;

--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -214,6 +214,7 @@
         <div class="ariane">
           <div
             class="ariane-wrapper"
+            :class="{ 'no-prev-next' : previousRefId === '' && nextRefId === '' }"
           >
             <!-- LeftTOC button -->
             <button
@@ -2822,6 +2823,10 @@ div.remove-bottom-padding #article {
     max-width: calc(100% - 90px - 20px);
     margin-right: 20px;
 
+    &.no-prev-next {
+      max-width: 100%;
+    }
+
     & > button.toc-menu-toggle {
       /* remove default button behavior */
       appearance: none;
@@ -3274,7 +3279,7 @@ ul.breadcrumb-top > li:nth-child(10) { z-index: 1; }
 
   position: absolute;
   top: 2px;
-  width: 10%; /* largeur du gradient */
+  width: 8%; /* largeur du gradient */
   height: 43px;
   z-index: 0;
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1059,8 +1059,8 @@ input[type=number] {
   }
 
   #home-article h1 {
-    padding: 0 0 10px;
-    font-size: 36px;
+    padding: 15px 0 10px;
+    font-size: 30px;
   }
 
   #home-article.article + a {


### PR DESCRIPTION
- Document scroll (router) with and without metadata
- Document page ; options button under opacity layer
- App structure on mobile (grid => block) 
- Breadcrumb scroll positioned on left of current item
- Notes at the bottom : ol styling
- Notes aside-bottom menu : FIX function finding notes in document content and footnotes
- Notes aside-bottom menu : fullwidth with images mode
- Notes number size
- Notes line-height in aside-bottom menu 
- Toggle Text/images mode on mobile